### PR TITLE
Update schedule reactions to be letters corresponding to the day

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ votes are placed via reactions.
 <you> .schedule MWF
 <Dndbot> @everyone When can you play next?
 
-         🇦: Monday
-         🇧: Wednesday
-         🇨: Friday
-        [🇦 1] [🇧 1] [🇨 1]
+         🇲: Monday
+         🇼: Wednesday
+         🇫: Friday
+         🙅: Unavailable
+        [🇲 1] [🇼 1] [🇫 1][🙅 0]
 ```
 
 **Dice Rolling**, .roll (alias: .r)

--- a/lib/scheduler.rb
+++ b/lib/scheduler.rb
@@ -1,27 +1,22 @@
 require "discordrb"
 
+DayOption = Struct.new(:initial, :name, :emoji)
 
 module Scheduler
   extend Discordrb::EventContainer
   extend Discordrb::Commands::CommandContainer
-
+  
   DAYS_FORMAT = /^[MTWRFSU]+$/i
-  ABBREVIATED_DAYS = {
-    "M" => "Monday",
-    "T" => "Tuesday",
-    "W" => "Wednesday",
-    "R" => "Thursday",
-    "F" => "Friday",
-    "S" => "Saturday",
-    "U" => "Sunday"
+  DAYS_OPTIONS = {
+    "M" => DayOption.new("M", "Monday", "\u{1F1F2}"),
+    "T" => DayOption.new("T", "Tuesday", "\u{1F1F9}"),
+    "W" => DayOption.new("W", "Wednesday", "\u{1F1FC}"),
+    "R" => DayOption.new("R", "Thursday", "\u{1F1F7}"),
+    "F" => DayOption.new("F", "Friday", "\u{1F1EB}"),
+    "S" => DayOption.new("S", "Saturday", "\u{1F1F8}"),
+    "U" => DayOption.new("U", "Sunday", "\u{1F1FA}")
   }
-  ALPHA_EMOJI = [
-    "\u{1F1E6}", "\u{1F1E7}", "\u{1F1E8}", "\u{1F1E9}", "\u{1F1EA}", "\u{1F1EB}", "\u{1F1EC}", "\u{1F1ED}", 
-    "\u{1F1EE}", "\u{1F1EF}", "\u{1F1F0}", "\u{1F1F1}", "\u{1F1F2}", "\u{1F1F3}", "\u{1F1F4}", "\u{1F1F5}", 
-    "\u{1F1F6}", "\u{1F1F7}", "\u{1F1F8}", "\u{1F1F9}", "\u{1F1FA}", "\u{1F1FB}", "\u{1F1FC}", "\u{1F1FD}", 
-    "\u{1F1EE}" 
-  ]
-  UNAVAILABLE_OPTION = {"Unavailable" => "\u{1F645}"}
+  UNAVAILABLE_OPTION = {"Unavailable" => DayOption.new("X", "Unavailable", "\u{1F645}"}
 
   command :schedule, {
     aliases: [:sched],
@@ -32,10 +27,9 @@ module Scheduler
     unless match = days.match(DAYS_FORMAT)
       event << "Invalid days provided: #{days}. Expected format `.schedule MTWRFSU`, `.schedule TWR`, etc."
     else
-      selected_days = days.split("").map { |day| ABBREVIATED_DAYS[day.upcase] }
-      options = selected_days.zip(ALPHA_EMOJI).to_h
+      options = days.split("").map { |day| DAYS_OPTIONS[day.upcase] }
       options = options.merge(UNAVAILABLE_OPTION)
-      options_txt = options.map { |day, emoji| "#{emoji}: #{day}" }.join("\n")
+      options_txt = options.map { |day| "#{day.emoji}: #{day.name}" }.join("\n")
 
       msg = event.channel.send_message <<~EOF
         @everyone When can you play next?
@@ -43,7 +37,7 @@ module Scheduler
         #{options_txt}
       EOF
 
-      options.each { |_, emoji| msg.react(emoji) }
+      options.each { |day| msg.react(day.emoji) }
     end
     nil
   end

--- a/lib/scheduler.rb
+++ b/lib/scheduler.rb
@@ -15,7 +15,7 @@ module Scheduler
     "S" => DayOption.new("S", "Saturday", "\u{1F1F8}"),
     "U" => DayOption.new("U", "Sunday", "\u{1F1FA}")
   }
-  UNAVAILABLE_OPTION = {"Unavailable" => DayOption.new("X", "Unavailable", "\u{1F645}"}
+  UNAVAILABLE_OPTION = {"Unavailable" => DayOption.new("X", "Unavailable", "\u{1F645}")}
 
   command :schedule, {
     aliases: [:sched],

--- a/lib/scheduler.rb
+++ b/lib/scheduler.rb
@@ -27,7 +27,7 @@ module Scheduler
       event << "Invalid days provided: #{days}. Expected format `.schedule MTWRFSU`, `.schedule TWR`, etc."
     else
       options = days.split("").map { |day| DAYS_OPTIONS[day.upcase] }
-      options = options.merge(UNAVAILABLE_OPTION)
+      options = options.push(UNAVAILABLE_OPTION)
       options_txt = options.map { |day| "#{day.emoji}: #{day.name}" }.join("\n")
 
       msg = event.channel.send_message <<~EOF

--- a/lib/scheduler.rb
+++ b/lib/scheduler.rb
@@ -5,7 +5,6 @@ DayOption = Struct.new(:initial, :name, :emoji)
 module Scheduler
   extend Discordrb::EventContainer
   extend Discordrb::Commands::CommandContainer
-  
   DAYS_FORMAT = /^[MTWRFSU]+$/i
   DAYS_OPTIONS = {
     "M" => DayOption.new("M", "Monday", "\u{1F1F2}"),

--- a/lib/scheduler.rb
+++ b/lib/scheduler.rb
@@ -15,7 +15,7 @@ module Scheduler
     "S" => DayOption.new("S", "Saturday", "\u{1F1F8}"),
     "U" => DayOption.new("U", "Sunday", "\u{1F1FA}")
   }
-  UNAVAILABLE_OPTION = {"Unavailable" => DayOption.new("X", "Unavailable", "\u{1F645}")}
+  UNAVAILABLE_OPTION = DayOption.new("X", "Unavailable", "\u{1F645}")
 
   command :schedule, {
     aliases: [:sched],

--- a/lib/scheduler.rb
+++ b/lib/scheduler.rb
@@ -28,7 +28,7 @@ module Scheduler
     else
       options = days.split("").map { |day| DAYS_OPTIONS[day.upcase] }
       options = options.push(UNAVAILABLE_OPTION)
-      options_txt = options.map { |day| "#{day.emoji}: #{day.name}" }.join("\n")
+      options_txt = options.map { |day| "#{day['emoji']}: #{day['name']}" }.join("\n")
 
       msg = event.channel.send_message <<~EOF
         @everyone When can you play next?
@@ -36,7 +36,7 @@ module Scheduler
         #{options_txt}
       EOF
 
-      options.each { |day| msg.react(day.emoji) }
+      options.each { |day| msg.react(day['emoji']) }
     end
     nil
   end


### PR DESCRIPTION
Change reaction emojis to match the day of the week that they are the reaction for, rather than simply being alphabetical beginning with "A".

"M" -> "Monday"
"T" -> "Tuesday"
"W" -> "Wednesday"
"R" -> "Thursday"
"F" -> "Friday"
"S" -> "Saturday"
"U" -> "Sunday"